### PR TITLE
Support Custom Slack Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ __NOTE__: The module supports up to 8 Fields in an [attachment](https://api.slac
 | icon_emoji            | SLACK_ICON_EMOJI    | Slack icon [emoji](https://www.webpagefx.com/tools/emoji-cheat-sheet) for the user's avatar                                          |
 | fallback              | SLACK_FALLBACK      | A plain-text summary of the attachment. This text will be used in clients that don't show formatted text                             |
 | color                 | SLACK_COLOR         | An optional value that can either be one of `good`, `warning`, `danger`, or a color code (_e.g._ `#439FE0`)                          |
+| channel               | SLACK_CHANNEL       | Slack channel to send to                                                                                                             |
 | pretext               | SLACK_PRETEXT       | Optional text that appears above the message attachment block                                                                        |
 | author_name           | SLACK_AUTHOR_NAME   | Small text to display the attachment author's name                                                                                   |
 | author_link           | SLACK_AUTHOR_LINK   | URL that will hyperlink the author's name. Will only work if `author_name` is present                                                |

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var (
 	iconEmoji   = flag.String("icon_emoji", os.Getenv("SLACK_ICON_EMOJI"), "Slack icon emoji for the user's avatar. https://www.webpagefx.com/tools/emoji-cheat-sheet")
 	fallback    = flag.String("fallback", os.Getenv("SLACK_FALLBACK"), "A plain-text summary of the attachment. This text will be used in clients that don't show formatted text")
 	color       = flag.String("color", os.Getenv("SLACK_COLOR"), "An optional value that can either be one of good, warning, danger, or any hex color code (e.g. #439FE0)")
+	channel     = flag.String("channel", os.Getenv("SLACK_CHANNEL"), "Slack channel to send to")
 	pretext     = flag.String("pretext", os.Getenv("SLACK_PRETEXT"), "Optional text that appears above the message attachment block")
 	authorName  = flag.String("author_name", os.Getenv("SLACK_AUTHOR_NAME"), "Small text to display the attachment author's name")
 	authorLink  = flag.String("author_link", os.Getenv("SLACK_AUTHOR_LINK"), "URL that will hyperlink the author's name. Will only work if author_name is present")
@@ -133,6 +134,7 @@ func main() {
 		Mrkdwn:      true,
 		Username:    *userName,
 		IconEmoji:   *iconEmoji,
+		Channel:     *channel,
 	}
 
 	notifier := NewSlackNotifier(*webhookURL)

--- a/slack_notifier.go
+++ b/slack_notifier.go
@@ -21,6 +21,7 @@ type Payload struct {
 	Mrkdwn      bool         `json:"mrkdwn"`
 	IconEmoji   string       `json:"icon_emoji"`
 	Username    string       `json:"username"`
+	Channel     string       `json:"channel"`
 }
 
 // Attachment for a Slack message


### PR DESCRIPTION
## what
* add `SLACK_CHANNEL` parameter

## why
* with this feature, one webhook url can be used to send to different channels