### PR TITLE
Upgraded to go version 1.20, added version to release artifacts and reduced final artifact sizes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ permissions:
   contents: write
 
 jobs:
-  goreleaser:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,35 +1,39 @@
-before:
-  hooks:
-    - go mod download
-
 builds:
   - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
       - CGO_ENABLED=0
-      - GO111MODULE=on
+    mod_timestamp: '{{ .CommitTimestamp }}'
     goos:
-      - linux
-      - windows
       - darwin
       - freebsd
-      - openbsd
-      - netbsd
+      - windows
+      - linux
     goarch:
       - amd64
       - '386'
       - arm
       - arm64
-      - s390x
-
-source:
-  enabled: true
-  name_template: 'sources'
+    ldflags:
+      # -s Omit the symbol table and debug information
+      # -w Omit the DWARF symbol table
+      # -X importpath.name=value # set the value of the string variable in importpath named name to value
+      # Someday we could implement a "version" command and set the version like this:
+      # - '-s -w -X "github.com/cloudposse/slack-notifier/cmd.Version={{.Env.GORELEASER_CURRENT_TAG}}"'
+      - '-s -w'
 
 archives:
   - format: binary
-    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
 
-snapshot:
-  name_template: "{{ incpatch .Version }}"
+release:
+# If you want to manually examine the release before it is live, uncomment this line:
+# draft: true
+
+changelog:
+  skip: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.13.3-buster as builder
+FROM golang:1.20.3-bullseye as builder
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 WORKDIR /usr/src/
 COPY . /usr/src
 RUN go build -v -o "bin/slack-notifier" *.go
 
-FROM alpine:3.12
+FROM alpine:3.17
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /usr/src/bin/* /usr/bin/
 ENV PATH $PATH:/usr/bin

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudposse/slack-notifier
 
-go 1.13
+go 1.20


### PR DESCRIPTION
## what
* Upgraded `go` version to `1.20`
* Added version to release artifacts
* Added compile options to remove debug data

## why
* Build with latest `go` version
* Reduced final artifact sizes
* Included versions into artifact names

## references
