### PR TITLE
Consolidate auto-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,17 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      # Get PR from merged commit to master
-      - uses: actions-ecosystem/action-get-merged-pull-request@v1
-        id: get-merged-pull-request
-        with:
-          github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
-
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
+      - uses: cloudposse/github-action-auto-release@v1
         with:
           publish: false
           prerelease: false
           config-name: draft-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## what
* Use `cloudposse/github-action-auto-release` in `auto-release.yaml` workflow

## why
* Solve old nodejs warning
* Reduce duplication of code
